### PR TITLE
Fix misspellings but allow the old for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ the Bolt 3.1+ version**
     [...]
     ```
 
- 3. Add the `is_translateable` argument to all fields you want to be
+ 3. Add the `translatable` argument to all fields you want to be
     translatable.
+
+    **Note: In older versions the config `translatable` was misspelled as
+    `is_translateable`. The old way is still supported, but deprecated and
+    will be removed in a future version.**
 
     ```
     [...]
@@ -61,21 +65,21 @@ the Bolt 3.1+ version**
         type: text
         class: large
         group: content
-        is_translateable: true
+        translatable: true
     [...]
 
     ```
     To translate templatefields you simply tag the templateselect
-    with `is_translateable` and all the templatefields will be translateable.
+    with `translatable` and all the templatefields will be translatable.
     ```
     [...]
     templateselect:
         type: templateselect
-        is_translateable: true
+        translatable: true
         filter: '*.twig'
     [...] 
     ```
- 4. Add the hidden fields to all the contenttypes that have translateable
+ 4. Add the hidden fields to all the contenttypes that have translatable
     fields, two for each locale: one called `your_localedata` and one called
     `your_localeslug`. So for the above `locales` example you would put:
 
@@ -155,22 +159,22 @@ pages:
             type: text
             class: large
             group: content
-            is_translateable: true
+            translatable: true
         slug:
             type: slug
             uses: title
-            is_translateable: true
+            translatable: true
         image:
             type: image
-            is_translateable: true
+            translatable: true
         teaser:
             type: html
             height: 150px
-            is_translateable: true
+            translatable: true
         body:
             type: html
             height: 300px
-            is_translateable: true
+            translatable: true
         template:
             type: templateselect
             filter: '*.twig'

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -30,7 +30,7 @@ url_generator_override: true
 
 # Enable/disable translated slugs.
 # Enabling this will use translated slugs instead of using the same slug for
-# all languages. Only set to false if you also don't set your slugs to `is_translateable`.
+# all languages. Only set to false if you also don't set your slugs to `translatable`.
 translate_slugs: true
 
 # Enable/disable using Accept-Language header to determine the locale for

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -276,12 +276,17 @@ class StorageListener implements EventSubscriberInterface
         $translatable = [];
         if (is_array($fields)) {
             foreach ($fields as $name => $field) {
-                if (isset($field['is_translateable']) &&
-                    $field['is_translateable'] === true &&
+                // Remove is_translateable when it is no longer supported
+                if (isset($field['is_translateable'])) {
+                    $field['translatable'] = $field['is_translateable'];
+                }
+                
+                if (isset($field['translatable']) &&
+                    $field['translatable'] === true &&
                     $field['type'] === 'templateselect'
                 ) {
                     $translatable[] = 'templatefields';
-                } elseif (isset($field['is_translateable']) && $field['is_translateable'] === true) {
+                } elseif (isset($field['translatable']) && $field['translatable'] === true) {
                     $translatable[] = $name;
                 }
             }

--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -3,7 +3,8 @@
 {% set translatable = [] %}
 
 {% for name, field in context.contenttype.fields %}
-    {% if field.is_translateable is defined and field.is_translateable == true %}
+    {# Remove is_translateable when it is no longer supported #}
+    {% if (field.translatable is defined and field.translatable == true) or (field.is_translateable is defined and field.is_translateable == true) %}
         {% set translatable = translatable|merge(['#'~name, '[name="'~name~'"]', '[name^="'~name~'[0]"]', '[name="'~name~'[file]"]']) %}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
Fix misspellings of translateable but allow the old for now.

Also shorten `is_translateable` to `translatable` to make it more aligned with `sortable` and so on.

Fixes #135

@lenvanessen sounds good to you?