### PR TITLE
 [WIP] Prevent Hydratation of empty repeater fields

### DIFF
--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -163,8 +163,10 @@ class StorageListener implements EventSubscriberInterface
             }
             /** @var RepeatingFieldCollection[] $subject */
             $subject[$key]->clear();
-            foreach ($value as $subValue) {
-                $subject[$key]->addFromArray($subValue);
+            if (is_array($value)) {
+                foreach ($value as $subValue) {
+                    $subject[$key]->addFromArray($subValue);
+                }
             }
         }
     }

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -124,8 +124,10 @@ class Legacy extends Storage
                         $mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
                         $record[$key] = new RepeatingFieldCollection($app['storage'], $mapping);
 
-                        foreach ($value as $subValue) {
-                            $record[$key]->addFromArray($subValue);
+                        if (is_array($value)) {
+                            foreach ($value as $subValue) {
+                                $record[$key]->addFromArray($subValue);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This commit fix a bug caused by an empty repeater field saved in default language, after that if you try to save the entry in other language than default cause exception `Warning: Invalid argument supplied for foreach() ` because there is no fields to iterate. 

Fixes: #147 
