### PR TITLE
Fixes #128

### DIFF
--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -225,7 +225,7 @@ class StorageListener implements EventSubscriberInterface
         }
 
         foreach ($translatableFields as $field) {
-            $localeValues[$field] = $values[$field];
+            $localeValues[$field] = isset($values[$field]) ? $values[$field] : null;
             if ($values['id']) {
                 $record->set($field, $defaultContent->get($field));
             } else {


### PR DESCRIPTION
Fixes #128 
When you add fields to the ContentType, after initially creating them, they don’t exist in the old dataset, until you open the entry and save it. This means translate was trying to grab an array index that isn't actually there, resulting in a undefined index error.