### PR TITLE
Make original record values available in twig from any locale

### DIFF
--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -45,7 +45,8 @@ class Legacy extends Storage
         } else {
             $content = new Content($app, $contenttype, $values);
         }
-
+        
+        $content['originalValues'] = $this->localeValues;
         return $content;
     }
 


### PR DESCRIPTION
Can be accessed in twig using {{ record.originalValues }}