### PR TITLE
Fix notices about missing indices

### DIFF
--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -24,7 +24,10 @@ class LocalizedFrontend extends Frontend
             }
 
             foreach ($routes as $name => &$route) {
-                if ($name !== 'preview' && $route['requirements']['_locale'] != 'none') {
+                if (
+                    $name !== 'preview'
+                    && (!isset($route['requirements']['_locale']) || $route['requirements']['_locale'] != 'none')
+                ) {
                     $route['path'] = '/{_locale}' . $route['path'];
                     $route['requirements']['_locale'] = $requirements;
                 }


### PR DESCRIPTION
Make sure we have a requirements/_locale key in a route before blindly checking it against a string.
This would result in notices thrown about missing indices. If the key isn't set at all in the route, we
should just blindly apply the default.