### PR TITLE
Hide hidden fields

### DIFF
--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -80,6 +80,9 @@
 </script>
 
 <style>
+    div[data-bolt-fieldset=locale] {
+        display: none;
+    }
     #locale-select button {
         border-radius: 4px 4px 0 0;
         padding: 5px 12px 4px;

--- a/templates/fields/_locale_data.twig
+++ b/templates/fields/_locale_data.twig
@@ -1,0 +1,5 @@
+<style>
+  div[data-bolt-fieldset=locale_data] {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
Hide the hidden fields completely in the backend, instead of displaying the default margins.