### PR TITLE
#192: Make language switcher at new contenttype page configurable

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -16,6 +16,9 @@ routing_override: true
 # Enable/disable showing of flag icons next to language names.
 show_flags: true
 
+# Enable/disable locale switcher on new contenttype pages
+show_switcher_on_new: false
+
 # Enable/disable the menubuilder override.
 # Enabling this will make the menu output links in the format of the automatic
 # routing. It is recommended that you leave this on unless you want to build

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -158,4 +158,20 @@ class Config extends ParameterBag
     {
         $this->set('translate_dashboard', $translateDashboard);
     }
+
+    /**
+     * @return boolean
+     */
+    public function isShowSwitcherOnNew()
+    {
+        return $this->getBoolean('show_switcher_on_new', false);
+    }
+
+    /**
+     * @param boolean $switcherOnNew
+     */
+    public function setShowSwitcherOnNew($switcherOnNew)
+    {
+        $this->set('show_switcher_on_new', $switcherOnNew);
+    }
 }

--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -18,7 +18,7 @@
 
 <fieldset class="locale">
     <div class="col-sm-12">
-        {% if app.request.get('id') is not empty %}
+        {% if app.request.get('id') is not empty or app['translate.config'].ShowSwitcherOnNew %}
         <div class="dropdown pull-right" id="locale-select">
             <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button">
                 <span class="selected">{{ flag_icon(currentkey) }} {{ current.get('label') }}</span>


### PR DESCRIPTION
This change makes the language switcher at new contenttype pages configurable, as requested in #192. The config-variable `show_switcher_on_new` can be used to add the language switcher to these pages.

Fixes: #192 
