### PR TITLE
Fix incorrect routing of non-existing records

### DIFF
--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -79,7 +79,13 @@ class LocalizedFrontend extends Frontend
 
         $result = $qb->execute()->fetch();
 
-        return parent::record($request, $contenttypeslug, $result['slug']);
+		if (null !== $result['slug']) {
+			return parent::record($request, $contenttypeslug, $result['slug']);
+		} else {
+            $this->abort(Response::HTTP_NOT_FOUND, "Page $contenttypeslug/$slug not found.");
+			
+            return null;
+		}
     }
 
     /**

--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -79,7 +79,7 @@ class LocalizedFrontend extends Frontend
 
         $result = $qb->execute()->fetch();
 
-        if (null !== $result['slug']) {
+        if ($result['slug'] !== null) {
             return parent::record($request, $contenttypeslug, $result['slug']);
         } else {
             $this->abort(Response::HTTP_NOT_FOUND, "Page $contenttypeslug/$slug not found.");

--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -79,13 +79,13 @@ class LocalizedFrontend extends Frontend
 
         $result = $qb->execute()->fetch();
 
-		if (null !== $result['slug']) {
-			return parent::record($request, $contenttypeslug, $result['slug']);
-		} else {
+        if (null !== $result['slug']) {
+            return parent::record($request, $contenttypeslug, $result['slug']);
+        } else {
             $this->abort(Response::HTTP_NOT_FOUND, "Page $contenttypeslug/$slug not found.");
 			
             return null;
-		}
+        }
     }
 
     /**


### PR DESCRIPTION
Record frontend controller incorrectly handles non-existing records. Atm, if you try accessing /entry/non-existing-entry if entry is translatable, instead of 404 you'll be redirected to the alphabetically first entry in the database. I added a condition that checks if the entered slug is actually present in the database, and if not, then it displays the 404 page.