### PR TITLE
Remember tab when switching locale

### DIFF
--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -114,3 +114,23 @@
         background-color: transparent !important;
     }
 </style>
+
+<script>
+    var localeTab = document.querySelector('#locale-select');
+
+    if (localeTab !== null) {
+        var links = localeTab.querySelectorAll('a');
+
+        window.onhashchange = function (){
+            var tab = window.location.hash.substr(1);
+
+            Array.prototype.forEach.call(links, function(link) {
+                var origHref = link.getAttribute('href').split('#')[0];
+
+                if (tab.length>0) {
+                    link.setAttribute('href', origHref + '#' + tab);
+                }
+            });
+        };
+    }
+</script>

--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -77,6 +77,24 @@
                 );
         {% endif %}
     });
+    
+    var localeTab = document.querySelector('#locale-select');
+
+    if (localeTab !== null) {
+        var links = localeTab.querySelectorAll('a');
+
+        window.onhashchange = function (){
+            var tab = window.location.hash.substr(1);
+
+            Array.prototype.forEach.call(links, function(link) {
+                var origHref = link.getAttribute('href').split('#')[0];
+
+                if (tab.length>0) {
+                    link.setAttribute('href', origHref + '#' + tab);
+                }
+            });
+        };
+    }
 </script>
 
 <style>
@@ -114,23 +132,3 @@
         background-color: transparent !important;
     }
 </style>
-
-<script>
-    var localeTab = document.querySelector('#locale-select');
-
-    if (localeTab !== null) {
-        var links = localeTab.querySelectorAll('a');
-
-        window.onhashchange = function (){
-            var tab = window.location.hash.substr(1);
-
-            Array.prototype.forEach.call(links, function(link) {
-                var origHref = link.getAttribute('href').split('#')[0];
-
-                if (tab.length>0) {
-                    link.setAttribute('href', origHref + '#' + tab);
-                }
-            });
-        };
-    }
-</script>


### PR DESCRIPTION
I've encountered a few usecases where I'd like the localelink to switch to the same tab in the other language. When an editor asked for it I decided to try and add that to the extension. See what you think!

