### PR TITLE
add missing locale field type

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -14,6 +14,8 @@ pages:
             class: large
             group: content
             translatable: true
+        locale:
+            type: locale
         slug:
             type: slug
             uses: title


### PR DESCRIPTION
without the a "locale" field type defined in a content type, the locale switcher is not displayed when editing a content type
